### PR TITLE
Allows (escaped) double quotes and semicolons in the filename.

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -278,7 +278,8 @@ IncomingForm.prototype._initMultipart = function(boundary) {
         part.name = m[1];
       }
 
-      if (m = headerValue.match(/filename="([^;]+)"/i)) {
+      if (m = headerValue.match(/filename="([^"\\]*(?:\\.[^"\\]*)*)"/i)) {
+        m[1] = m[1].replace(/\\"/ig, '"');
         part.filename = m[1].substr(m[1].lastIndexOf('\\') + 1);
       }
     } else if (headerField == 'content-type') {


### PR DESCRIPTION
Hi,

I ran in the problem that I couldn't upload files with semicolons in the filename. I tried the patch from abram (https://github.com/felixge/node-formidable/pull/58) but this patch raises problems with filenames that have double quotes in their filename.

So I came up with this patch to fix both issues.

As an example:

The file `b'e";e.JPG` on my local machine is being uploaded, so the multipart header looks like (wireshark excerpt):

`Content-Disposition: form-data; name="file"; filename="b'e\";e.JPG"`

Note that the browser did escape the double quotes properly. 

Thanks for the great module!

Simon
