### PR TITLE
Do not ignore Content-Transfer-Encoding for multipart POST

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -164,7 +164,7 @@ IncomingForm.prototype.handlePart = function(part) {
 
   if (part.filename === undefined) {
     var value = ''
-      , decoder = new StringDecoder(this.encoding);
+      , decoder = new StringDecoder(part.encoding || this.encoding);
 
     part.on('data', function(buffer) {
       self._fieldsSize += buffer.length;
@@ -271,6 +271,7 @@ IncomingForm.prototype._initMultipart = function(boundary) {
     part.name = null;
     part.filename = null;
     part.mime = null;
+    part.encoding = null;
     headerField = '';
     headerValue = '';
   };
@@ -296,6 +297,8 @@ IncomingForm.prototype._initMultipart = function(boundary) {
       part.filename = self._fileName(headerValue);
     } else if (headerField == 'content-type') {
       part.mime = headerValue;
+    } else if (headerField == 'content-transfer-encoding') {
+      part.encoding = headerValue;
     }
 
     headerField = '';


### PR DESCRIPTION
A part of a multipart POST field may have its own encoding. This commit uses that, if present, before defaulting to IncomingForm.encoding.
