### PR TITLE
Tests should throw deprecation errors

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -16,3 +16,5 @@ exports.assert     = require('assert');
 exports.require = function(lib) {
   return require(exports.dir.lib + '/' + lib);
 };
+
+process.throwDeprecation = true


### PR DESCRIPTION
While the library itself will not throw, tests should. Developers should
always avoid deprecat(ed|ing) code / api's.

Signed-off-by: Tim Smart tim@fostle.com
