### PR TITLE
Add tests for file sizes and hashes, fix node 0.11

### DIFF
--- a/benchmark/bench-multipart-parser.js
+++ b/benchmark/bench-multipart-parser.js
@@ -59,8 +59,8 @@ function createMultipartBuffer(boundary, size) {
     , tail = '\r\n--'+boundary+'--\r\n'
     , buffer = new Buffer(size);
 
-  buffer.write(head, 'ascii', 0);
-  buffer.write(tail, 'ascii', buffer.length - tail.length);
+  buffer.write(head, 0, 'ascii');
+  buffer.write(tail, buffer.length - tail.length, 'ascii');
   return buffer;
 }
 

--- a/lib/multipart_parser.js
+++ b/lib/multipart_parser.js
@@ -58,8 +58,8 @@ MultipartParser.stateToString = function(stateNumber) {
 
 MultipartParser.prototype.initWithBoundary = function(str) {
   this.boundary = new Buffer(str.length+4);
-  this.boundary.write('\r\n--', 'ascii', 0);
-  this.boundary.write(str, 'ascii', 4);
+  this.boundary.write('\r\n--', 0, 'ascii');
+  this.boundary.write(str, 4, 'ascii');
   this.lookbehind = new Buffer(this.boundary.length+8);
   this.state = S.START;
 

--- a/test/fixture/js/encoding.js
+++ b/test/fixture/js/encoding.js
@@ -1,24 +1,24 @@
 module.exports['menu_seperator.png.http'] = [
   {type: 'file', name: 'image', filename: 'menu_separator.png', fixture: 'menu_separator.png',
-  sha1: 'c845ca3ea794be298f2a1b79769b71939eaf4e54'}
+  sha1: 'c845ca3ea794be298f2a1b79769b71939eaf4e54', size: 931}
 ];
 
 module.exports['beta-sticker-1.png.http'] = [
   {type: 'file', name: 'sticker', filename: 'beta-sticker-1.png', fixture: 'beta-sticker-1.png',
-  sha1: '6abbcffd12b4ada5a6a084fe9e4584f846331bc4'}
+  sha1: '6abbcffd12b4ada5a6a084fe9e4584f846331bc4', size: 1660}
 ];
 
 module.exports['blank.gif.http'] = [
   {type: 'file', name: 'file', filename: 'blank.gif', fixture: 'blank.gif',
-  sha1: 'a1fdee122b95748d81cee426d717c05b5174fe96'}
+  sha1: 'a1fdee122b95748d81cee426d717c05b5174fe96', size: 49}
 ];
 
 module.exports['binaryfile.tar.gz.http'] = [
   {type: 'file', name: 'file', filename: 'binaryfile.tar.gz', fixture: 'binaryfile.tar.gz',
-  sha1: 'cfabe13b348e5e69287d677860880c52a69d2155'}
+  sha1: 'cfabe13b348e5e69287d677860880c52a69d2155', size: 301}
 ];
 
 module.exports['plain.txt.http'] = [
   {type: 'file', name: 'file', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'}
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23}
 ];

--- a/test/fixture/js/no-filename.js
+++ b/test/fixture/js/no-filename.js
@@ -1,9 +1,9 @@
 module.exports['generic.http'] = [
   {type: 'file', name: 'upload', filename: '', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];
 
 module.exports['filename-name.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];

--- a/test/fixture/js/preamble.js
+++ b/test/fixture/js/preamble.js
@@ -1,9 +1,9 @@
 module.exports['crlf.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];
 
 module.exports['preamble.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];

--- a/test/fixture/js/workarounds.js
+++ b/test/fixture/js/workarounds.js
@@ -1,8 +1,8 @@
 module.exports['missing-hyphens1.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];
 module.exports['missing-hyphens2.http'] = [
   {type: 'file', name: 'upload', filename: 'plain.txt', fixture: 'plain.txt',
-  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872'},
+  sha1: 'b31d07bac24ac32734de88b3687dddb10e976872', size: 23},
 ];

--- a/test/integration/test-fixtures.js
+++ b/test/integration/test-fixtures.js
@@ -49,6 +49,7 @@ function testNext(fixtures) {
       if (parsedPart.type === 'file') {
         var file = parsedPart.value;
         assert.equal(file.name, expectedPart.filename);
+        if(expectedPart.size) assert.equal(file.size, expectedPart.size);
         if(expectedPart.sha1) assert.equal(file.hash, expectedPart.sha1);
       }
     });

--- a/test/legacy/integration/test-multipart-parser.js
+++ b/test/legacy/integration/test-multipart-parser.js
@@ -50,7 +50,7 @@ Object.keys(fixtures).forEach(function(name) {
     endCalled = true;
   };
 
-  buffer.write(fixture.raw, 'binary', 0);
+  buffer.write(fixture.raw, 0, 'binary');
 
   while (offset < buffer.length) {
     if (offset + CHUNK_LENGTH < buffer.length) {

--- a/test/legacy/simple/test-multipart-parser.js
+++ b/test/legacy/simple/test-multipart-parser.js
@@ -34,7 +34,7 @@ test(function parserError() {
       buffer = new Buffer(5);
 
   parser.initWithBoundary(boundary);
-  buffer.write('--ad', 'ascii', 0);
+  buffer.write('--ad', 0, 'ascii');
   assert.equal(parser.write(buffer), 5);
 });
 


### PR DESCRIPTION
Merges #210 into latest master. Some deprecation warnings cropped up in node
0.11 so 9ddedc9 fixes those.

Still waiting for joyent/node#5715 to be fixed to be completely compatible with
node >=0.11.2

This should probably be split into two pull requests but I'm lazy :)
