### PR TITLE
Added support for uploading files to buffer instead of filesystem

### DIFF
--- a/example/post.js
+++ b/example/post.js
@@ -1,11 +1,13 @@
 require('../test/common');
 var http = require('http'),
     util = require('util'),
-    formidable = require('formidable'),
+    formidable = require('../index'), // Change '../index' to 'formidable' in a real example
     server;
 
+var TEST_PORT = process.argv[2] || 3000;
+
 server = http.createServer(function(req, res) {
-  if (req.url == '/') {
+  if (req.url === '/') {
     res.writeHead(200, {'content-type': 'text/html'});
     res.end(
       '<form action="/post" method="post">'+
@@ -14,7 +16,7 @@ server = http.createServer(function(req, res) {
       '<input type="submit" value="Submit">'+
       '</form>'
     );
-  } else if (req.url == '/post') {
+  } else if (req.url === '/post') {
     var form = new formidable.IncomingForm(),
         fields = [];
 

--- a/example/post.js
+++ b/example/post.js
@@ -1,7 +1,7 @@
 require('../test/common');
 var http = require('http'),
     util = require('util'),
-    formidable = require('../index'), // Change '../index' to 'formidable' in a real example
+    formidable = require('..'), // Change '..' to 'formidable' in your code
     server;
 
 var TEST_PORT = process.argv[2] || 3000;

--- a/example/upload.js
+++ b/example/upload.js
@@ -1,7 +1,7 @@
 require('../test/common');
 var http = require('http'),
     util = require('util'),
-    formidable = require('../index'), // Change '../index' to 'formidable' in a real example
+    formidable = require('../index'), // Change '..' to 'formidable' in your code
     server;
 
 var TEST_TMP = process.env.TMP || process.env.TMPDIR || process.env.TEMP || '/tmp' || process.cwd();

--- a/example/upload.js
+++ b/example/upload.js
@@ -1,7 +1,7 @@
 require('../test/common');
 var http = require('http'),
     util = require('util'),
-    formidable = require('../index'),
+    formidable = require('../index'), // Change this to require('formidable') in a real example
     server;
 
 var TEST_TMP = process.env.TMP || process.env.TMPDIR || process.env.TEMP || '/tmp' || process.cwd();

--- a/example/upload.js
+++ b/example/upload.js
@@ -18,7 +18,7 @@ server = http.createServer(function(req, res) {
       '</form>'
     );
   } else if (req.url === '/upload') {
-    var form = new formidable.IncomingForm({noFile: true}),
+    var form = new formidable.IncomingForm({noFileSystem: true}),
         files = [],
         fields = [];
 

--- a/example/upload.js
+++ b/example/upload.js
@@ -1,7 +1,7 @@
 require('../test/common');
 var http = require('http'),
     util = require('util'),
-    formidable = require('../index'), // Change this to require('formidable') in a real example
+    formidable = require('../index'), // Change '../index' to 'formidable' in a real example
     server;
 
 var TEST_TMP = process.env.TMP || process.env.TMPDIR || process.env.TEMP || '/tmp' || process.cwd();

--- a/example/upload.js
+++ b/example/upload.js
@@ -18,7 +18,7 @@ server = http.createServer(function(req, res) {
       '</form>'
     );
   } else if (req.url === '/upload') {
-    var form = new formidable.IncomingForm(),
+    var form = new formidable.IncomingForm({noFile: true}),
         files = [],
         fields = [];
 

--- a/example/upload.js
+++ b/example/upload.js
@@ -1,11 +1,14 @@
 require('../test/common');
 var http = require('http'),
     util = require('util'),
-    formidable = require('formidable'),
+    formidable = require('../index'),
     server;
 
+var TEST_TMP = process.env.TMP || process.env.TMPDIR || process.env.TEMP || '/tmp' || process.cwd();
+var TEST_PORT = process.argv[2] || 3000;
+
 server = http.createServer(function(req, res) {
-  if (req.url == '/') {
+  if (req.url === '/') {
     res.writeHead(200, {'content-type': 'text/html'});
     res.end(
       '<form action="/upload" enctype="multipart/form-data" method="post">'+
@@ -14,7 +17,7 @@ server = http.createServer(function(req, res) {
       '<input type="submit" value="Upload">'+
       '</form>'
     );
-  } else if (req.url == '/upload') {
+  } else if (req.url === '/upload') {
     var form = new formidable.IncomingForm(),
         files = [],
         fields = [];

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -30,6 +30,10 @@ function IncomingForm(opts) {
   this.headers = null;
   this.type = null;
   this.hash = opts.hash || false;
+  this.noFile = opts.noFile || false;
+  this.buffers = [];
+  this.finalBuffer = null;
+  this.finalBufferLength = 0;
 
   this.bytesReceived = null;
   this.bytesExpected = null;
@@ -161,8 +165,44 @@ IncomingForm.prototype.resume = function() {
 
 IncomingForm.prototype.onPart = function(part) {
   // this method can be overwritten by the user
-  this.handlePart(part);
+  if (this.noFile) {
+    this.handlePartBuffer(part);
+  }
+  else {
+    this.handlePart(part);
+  }
 };
+
+IncomingForm.prototype.handlePartBuffer = function(part) {
+  var self = this;
+
+  part.on('data', function(buffer) {
+    if (buffer.length == 0) {
+      return;
+    }
+    this.buffers.push(buffer);
+    this.finalBufferLength += buffer.length;
+    //self.pause();
+    //file.write(buffer, function() {
+    //  self.resume();
+    //});
+  });
+
+  part.on('end', function() {
+    this.finalBuffer = new Buffer(finalLength);
+    i = 0, offset = 0;
+    for (i=0; i<buffers.length; i++) {
+      this.buffers[i].copy(this.finalBuffer, offset);
+      offset += this.buffers[i].length;
+    }
+
+    //file.end(function() {
+    //  self._flushing--;
+    //  self.emit('file', part.name, file);
+    //  self._maybeEnd();
+    //});
+  });
+}
 
 IncomingForm.prototype.handlePart = function(part) {
   var self = this;

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -30,7 +30,7 @@ function IncomingForm(opts) {
   this.headers = null;
   this.type = null;
   this.hash = opts.hash || false;
-  this.noFile = opts.noFile || false;
+  this.noFileSystem = opts.noFileSystem || false;
   this.files = [];
 
   this.bytesReceived = null;
@@ -189,7 +189,7 @@ IncomingForm.prototype.handlePart = function(part) {
   }
 
   // Upload file(s) to self.files instead of to filesystem
-  if (this.noFile) {
+  if (this.noFileSystem) {
     part.on('data', function(buffer) {
       if (buffer.length === 0) {
         return;

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -176,12 +176,31 @@ IncomingForm.prototype.onPart = function(part) {
 IncomingForm.prototype.handlePartBuffer = function(part) {
   var self = this;
 
+  if (part.filename === undefined) {
+    var value = ''
+      , decoder = new StringDecoder(this.encoding);
+
+    part.on('data', function(buffer) {
+      self._fieldsSize += buffer.length;
+      if (self._fieldsSize > self.maxFieldsSize) {
+        self._error(new Error('maxFieldsSize exceeded, received '+self._fieldsSize+' bytes of field data'));
+        return;
+      }
+      value += decoder.write(buffer);
+    });
+
+    part.on('end', function() {
+      self.emit('field', part.name, value);
+    });
+    return;
+  }
+
   part.on('data', function(buffer) {
-    if (buffer.length == 0) {
+    if (buffer.length === 0) {
       return;
     }
-    this.buffers.push(buffer);
-    this.finalBufferLength += buffer.length;
+    self.buffers.push(buffer);
+    self.finalBufferLength += buffer.length;
     //self.pause();
     //file.write(buffer, function() {
     //  self.resume();
@@ -189,13 +208,15 @@ IncomingForm.prototype.handlePartBuffer = function(part) {
   });
 
   part.on('end', function() {
-    this.finalBuffer = new Buffer(this.finalBufferLength);
+    //console.log(this.finalBufferLength);
+    self.finalBuffer = new Buffer(self.finalBufferLength);
     i = 0, offset = 0;
-    for (i=0; i<buffers.length; i++) {
-      this.buffers[i].copy(this.finalBuffer, offset);
-      offset += this.buffers[i].length;
+    for (i=0; i<self.buffers.length; i++) {
+      self.buffers[i].copy(self.finalBuffer, offset);
+      offset += self.buffers[i].length;
     }
 
+    self.emit('file', part.name, self.finalBuffer.toString('utf8'));
     //file.end(function() {
     //  self._flushing--;
     //  self.emit('file', part.name, file);

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -189,7 +189,7 @@ IncomingForm.prototype.handlePartBuffer = function(part) {
   });
 
   part.on('end', function() {
-    this.finalBuffer = new Buffer(finalLength);
+    this.finalBuffer = new Buffer(this.finalBufferLength);
     i = 0, offset = 0;
     for (i=0; i<buffers.length; i++) {
       this.buffers[i].copy(this.finalBuffer, offset);

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -165,65 +165,8 @@ IncomingForm.prototype.resume = function() {
 
 IncomingForm.prototype.onPart = function(part) {
   // this method can be overwritten by the user
-  if (this.noFile) {
-    this.handlePartBuffer(part);
-  }
-  else {
-    this.handlePart(part);
-  }
+  this.handlePart(part);
 };
-
-IncomingForm.prototype.handlePartBuffer = function(part) {
-  var self = this;
-
-  if (part.filename === undefined) {
-    var value = ''
-      , decoder = new StringDecoder(this.encoding);
-
-    part.on('data', function(buffer) {
-      self._fieldsSize += buffer.length;
-      if (self._fieldsSize > self.maxFieldsSize) {
-        self._error(new Error('maxFieldsSize exceeded, received '+self._fieldsSize+' bytes of field data'));
-        return;
-      }
-      value += decoder.write(buffer);
-    });
-
-    part.on('end', function() {
-      self.emit('field', part.name, value);
-    });
-    return;
-  }
-
-  part.on('data', function(buffer) {
-    if (buffer.length === 0) {
-      return;
-    }
-    self.buffers.push(buffer);
-    self.finalBufferLength += buffer.length;
-    //self.pause();
-    //file.write(buffer, function() {
-    //  self.resume();
-    //});
-  });
-
-  part.on('end', function() {
-    //console.log(this.finalBufferLength);
-    self.finalBuffer = new Buffer(self.finalBufferLength);
-    i = 0, offset = 0;
-    for (i=0; i<self.buffers.length; i++) {
-      self.buffers[i].copy(self.finalBuffer, offset);
-      offset += self.buffers[i].length;
-    }
-
-    self.emit('file', part.name, self.finalBuffer.toString('utf8'));
-    //file.end(function() {
-    //  self._flushing--;
-    //  self.emit('file', part.name, file);
-    //  self._maybeEnd();
-    //});
-  });
-}
 
 IncomingForm.prototype.handlePart = function(part) {
   var self = this;
@@ -247,37 +190,61 @@ IncomingForm.prototype.handlePart = function(part) {
     return;
   }
 
-  this._flushing++;
-
-  var file = new File({
-    path: this._uploadPath(part.filename),
-    name: part.filename,
-    type: part.mime,
-    hash: self.hash
-  });
-
-  this.emit('fileBegin', part.name, file);
-
-  file.open();
-  this.openedFiles.push(file);
-
-  part.on('data', function(buffer) {
-    if (buffer.length == 0) {
-      return;
-    }
-    self.pause();
-    file.write(buffer, function() {
-      self.resume();
+  // Upload file to buffer
+  if (this.noFile) {
+    part.on('data', function(buffer) {
+      if (buffer.length === 0) {
+        return;
+      }
+      self.buffers.push(buffer);
+      self.finalBufferLength += buffer.length;
     });
-  });
 
-  part.on('end', function() {
-    file.end(function() {
-      self._flushing--;
-      self.emit('file', part.name, file);
-      self._maybeEnd();
+    part.on('end', function() {
+      self.finalBuffer = new Buffer(self.finalBufferLength);
+      i = 0, offset = 0;
+      for (i=0; i<self.buffers.length; i++) {
+        self.buffers[i].copy(self.finalBuffer, offset);
+        offset += self.buffers[i].length;
+      }
+      self.buffers = [];
+      self.finalBufferLength = 0;
+      self.emit('file', part.name, self.finalBuffer.toString(self.encoding));
     });
-  });
+  }
+  else {
+    this._flushing++;
+
+    var file = new File({
+      path: this._uploadPath(part.filename),
+      name: part.filename,
+      type: part.mime,
+      hash: self.hash
+    });
+
+    this.emit('fileBegin', part.name, file);
+
+    file.open();
+    this.openedFiles.push(file);
+
+    part.on('data', function(buffer) {
+      if (buffer.length == 0) {
+        return;
+      }
+      self.pause();
+      file.write(buffer, function() {
+        self.resume();
+      });
+    });
+
+    part.on('end', function() {
+      file.end(function() {
+        self._flushing--;
+        self.emit('file', part.name, file);
+        self._maybeEnd();
+      });
+    });
+  }
 };
 
 function dummyParser(self) {

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -31,9 +31,7 @@ function IncomingForm(opts) {
   this.type = null;
   this.hash = opts.hash || false;
   this.noFile = opts.noFile || false;
-  this.buffers = [];
-  this.finalBuffer = null;
-  this.finalBufferLength = 0;
+  this.files = [];
 
   this.bytesReceived = null;
   this.bytesExpected = null;
@@ -190,26 +188,44 @@ IncomingForm.prototype.handlePart = function(part) {
     return;
   }
 
-  // Upload file to buffer
+  // Upload file(s) to self.files instead of to filesystem
   if (this.noFile) {
     part.on('data', function(buffer) {
       if (buffer.length === 0) {
         return;
       }
-      self.buffers.push(buffer);
-      self.finalBufferLength += buffer.length;
+      var i = 0;
+      var new_file = true;
+      for (i=0; i<self.files.length; i++) {
+        if (self.files[i].filename === part.filename) {
+          new_file = false;
+          self.files[i].buffers.push(buffer);
+          self.files[i].length += buffer.length;
+          break;
+        }
+      }
+      if (new_file) {
+        self.files.push({
+          filename: part.filename, 
+          length: buffer.length,
+          buffers: [buffer],
+          file: null
+        });
+      }
     });
 
     part.on('end', function() {
-      self.finalBuffer = new Buffer(self.finalBufferLength);
-      i = 0, offset = 0;
-      for (i=0; i<self.buffers.length; i++) {
-        self.buffers[i].copy(self.finalBuffer, offset);
-        offset += self.buffers[i].length;
+      var i = 0, j = 0, offset = 0;
+      for (i=0; i<self.files.length; i++) {
+        offset = 0;
+        self.files[i].file = new Buffer(self.files[i].length);
+        for (j=0; j<self.files[i].buffers.length; j++) {
+          self.files[i].buffers[j].copy(self.files[i].file, offset);
+          offset += self.files[i].buffers[j].length;
+        }
+        self.files[i].buffers = [];
+        self.emit('file', part.name, self.files[i].file.toString(self.encoding));
       }
-      self.buffers = [];
-      self.finalBufferLength = 0;
-      self.emit('file', part.name, self.finalBuffer.toString(self.encoding));
     });
   }
   else {


### PR DESCRIPTION
A while ago, I encountered a problem uploading images >1MB to a Nodejitsu instance. I assume that cloud hosting providers like Nodejitsu do not always support a large filesystem for node.js instances. Since I needed to upload the file to the server before pushing it to an image hosting service, I modified node-formidable to support uploading files to Buffers instead of to the filesystem. 
