### PR TITLE
Update incoming_form.js

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -25,7 +25,7 @@ function IncomingForm(opts) {
   this.maxFields = opts.maxFields || 1000;
   this.maxFieldsSize = opts.maxFieldsSize || 2 * 1024 * 1024;
   this.keepExtensions = opts.keepExtensions || false;
-  this.uploadDir = opts.uploadDir || os.tmpDir();
+  this.uploadDir = opts.uploadDir || os.tmpDir;
   this.encoding = opts.encoding || 'utf-8';
   this.headers = null;
   this.type = null;


### PR DESCRIPTION
In line 28, os.tmpDir is a variable, not a function.
Changing line to this.uploadDir = opts.uploadDir || os.tmpDir;
will fix issue of "Object #<Object> has no method 'tmpDir'"
