### PR TITLE
Force form.multiples to always return array

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -91,7 +91,10 @@ IncomingForm.prototype.parse = function(req, cb) {
             }
             files[name].push(file);
           } else {
-            files[name] = file;
+            if (!Array.isArray(files[name])) {
+              files[name] = [];
+            }
+            files[name].push(file);
           }
         } else {
           files[name] = file;


### PR DESCRIPTION
When uploading one file to a formidable with form.multiples = true then the req.files.[name] would just be the file instead should be array of files as suggested by the documentation.
