### PR TITLE
Exposing file writable stream errors through the form

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -31,7 +31,11 @@ module.exports = File;
 util.inherits(File, EventEmitter);
 
 File.prototype.open = function() {
+  var self = this;
   this._writeStream = new WriteStream(this.path);
+  this._writeStream.on('error', function(err) {
+    self.emit('error', err);
+  })
 };
 
 File.prototype.toJSON = function() {

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -207,10 +207,6 @@ IncomingForm.prototype.handlePart = function(part) {
     hash: self.hash
   });
 
-  file.on('error', function(err) {
-    self.emit('error', err);
-  });
-
   this.emit('fileBegin', part.name, file);
 
   file.open();
@@ -232,6 +228,10 @@ IncomingForm.prototype.handlePart = function(part) {
       self.emit('file', part.name, file);
       self._maybeEnd();
     });
+  });
+
+  file.on('error', function(err) {
+    self.emit('error', err);
   });
 };
 

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -207,6 +207,10 @@ IncomingForm.prototype.handlePart = function(part) {
     hash: self.hash
   });
 
+  file.on('error', function(err) {
+    self.emit('error', err);
+  });
+
   this.emit('fileBegin', part.name, file);
 
   file.open();


### PR DESCRIPTION
I have an `uploadDir` that can be removed while the form still references it. I would like to catch the error if this is the case through the form, like:

```
form.on('error', function(err) {
    // handle error
});
```

Or is there any other solution to catch the absence of `uploadDir`?
