### PR TITLE
Add support for array-like fields

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -120,7 +120,7 @@ If you want checksums calculated for incoming files, set this to either `'sha1'`
 ```javascript
 form.multiples = false;
 ```
-If this option is enabled, when you call `form.parse`, the `files` argument will contain arrays of files for inputs which submit multiple files using the HTML5 `multiple` attribute.
+If this option is enabled, when you call `form.parse`, the `files` argument will contain arrays of files for inputs which submit multiple files using the HTML5 `multiple` attribute. Also, the `fields` argument will contain arrays of values for fields that have names ending with '[]'.
 
 ```javascript
 form.bytesReceived

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -82,7 +82,21 @@ IncomingForm.prototype.parse = function(req, cb) {
     var fields = {}, files = {};
     this
       .on('field', function(name, value) {
-        fields[name] = value;
+        if (this.multiples && name.substr(name.length-2) === '[]') {
+          name = name.substr(0, name.length-2);
+          if (fields[name]) {
+            if (!Array.isArray(fields[name])) {
+              fields[name] = [fields[name]];
+            }
+            fields[name].push(value);
+          }
+          else {
+            fields[name] = value;
+          }
+        }
+        else {
+          fields[name] = value;
+        }
       })
       .on('file', function(name, file) {
         if (this.multiples) {


### PR DESCRIPTION
This is a very basic feature to add, and I know it's a "feature", but allow me to state my case.

One may not want this feature (I can argue that most would, but that's just my opinion), and currently when someone wants this feature, they must write their own parse function. However, with this feature, one could write their own parse function if they don't want this feature (or they could just not enable it via the multiples option). So, either way, the default parse method could (and should IMO) include this feature; if someone doesn't want this feature they can write their own parse function. 

Besides, why would someone ever complain about this feature when it's so unobtrusive? It would only if someone wanted their name had the `[]` suffix at the end for whatever reason (maybe they like boxes or something).

I see no argument against this feature, so let's solve this issue: https://github.com/felixge/node-formidable/issues/33
