### PR TITLE
Array parameters support

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -82,7 +82,20 @@ IncomingForm.prototype.parse = function(req, cb) {
     var fields = {}, files = {};
     this
       .on('field', function(name, value) {
-        fields[name] = value;
+        var index = name.indexOf('[]');
+        if (index === name.length - 2) {
+          var realName = name.substring(0, index);
+          if (fields.hasOwnProperty(realName)) {
+            if (!Array.isArray(fields[realName])) {
+              fields[realName] = [fields[realName]];
+            }
+          } else {
+            fields[realName] = [];
+          }
+          fields[realName].push(value);
+        } else {
+          fields[name] = value;
+        }
       })
       .on('file', function(name, file) {
         if (this.multiples) {

--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -82,10 +82,9 @@ IncomingForm.prototype.parse = function(req, cb) {
     var fields = {}, files = {};
     this
       .on('field', function(name, value) {
-        var index = name.indexOf('[]');
-        if (index === name.length - 2) {
-          var realName = name.substring(0, index);
-          if (fields.hasOwnProperty(realName)) {
+        if (name.slice(-2) === '[]') {
+          var realName = name.slice(0, name.length - 2);
+          if (realName in fields) {
             if (!Array.isArray(fields[realName])) {
               fields[realName] = [fields[realName]];
             }


### PR DESCRIPTION
- This PR makes it available to send requests like the following:
  `curl 'http://host/upload/with/params' -F 'topic=chat10' -F 'members[]=member_one@host.com' -F 'members[]=member_two@host.com' -F 'userfile=@./gplus.png'`
- Also it allows to distinguish the parameter type, whether it should be an array or not. It's important when the endpoint excpects the incoming parameters to be exactly of a certain type.
- Fixes the issue #138 
