### PR TITLE
close write stream not correctly when error occurs

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -298,7 +298,7 @@ IncomingForm.prototype._error = function(err) {
 
   if (Array.isArray(this.openedFiles)) {
     this.openedFiles.forEach(function(file) {
-      file._writeStream.destroy();
+      file.end();
       setTimeout(fs.unlink, 0, file.path, function(error) { });
     });
   }


### PR DESCRIPTION
When submit form error, for example field size over maxFieldsSize, the node process will exit with the followed messages, it seems close write stream not rightly, I don't find destroy() method for writable stream from the node document, so I think use the end() function for File object is a good choice.

events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: EBADF: bad file descriptor, close
    at Error (native)
