### PR TITLE
added a keepFilenames option to IncomingForm constructor

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -27,6 +27,7 @@ function IncomingForm(opts) {
   this.maxFieldsSize = opts.maxFieldsSize || 20 * 1024 * 1024;
   this.maxFileSize = opts.maxFileSize || 200 * 1024 * 1024;
   this.keepExtensions = opts.keepExtensions || false;
+  this.keepFilenames = opts.keepFilenames || false;
   this.uploadDir = opts.uploadDir || (os.tmpdir && os.tmpdir()) || os.tmpDir();
   this.encoding = opts.encoding || 'utf-8';
   this.headers = null;
@@ -537,7 +538,7 @@ IncomingForm.prototype._initJSONencoded = function() {
 
 IncomingForm.prototype._uploadPath = function(filename) {
   var buf = crypto.randomBytes(16);
-  var name = 'upload_' + buf.toString('hex');
+  var name = this.keepFilenames ? filename : 'upload_' + buf.toString('hex');
 
   if (this.keepExtensions) {
     var ext = path.extname(filename);


### PR DESCRIPTION
Hi all, I found formidable to be a very useful library, but did not see a way to simply use the original filename as the destination pathname, so I am making that pull request in case you feel it can be included.

From what I can tell the code would otherwise use content-disposition headers if they carried filenames with them, but my barebones HTML form didn't send those headers, so I get the randomly generated hex filenames, even though the original name is sitting right on that File object (as `.name`).

Maybe I'm missing something simple in how to include filenames from the clientside, but either way, let me know!