### PR TITLE
throw error during data parsing

### DIFF
--- a/lib/incoming_form.js
+++ b/lib/incoming_form.js
@@ -122,7 +122,11 @@ IncomingForm.prototype.parse = function(req, cb) {
       self._error(new Error('Request aborted'));
     })
     .on('data', function(buffer) {
-      self.write(buffer);
+      try {
+        self.write(buffer);
+      } catch (err) {
+        self._error(err);
+      }
     })
     .on('end', function() {
       if (self.error) {


### PR DESCRIPTION
fix: the following request will cause uncatched error when parsed by formidable.
```
const fs = require('fs');
const path = require('path');
const request = require('request');
const multipartData = [
  {name: 'my_field', body: 'my_value'},
  {name: 'my_number', body: 1000},
  {name: 'my_buffer', body: Buffer.from([1, 2, 3])},
  {name: 'my_file', body: fs.createReadStream(path.resolve(__dirname, 'multipart.js'))},
  // {name: 'remote_file', body: request(url + '/file')}
];

var reqOptions = {
  url,
  multipart: multipartData
}
request.post(reqOptions, function (err, res, body) {
  console.log(body);
})
```