### PR TITLE
feat: don't promote IncomingForm; support `exports.default` (esm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
  * Array support for fields and files ([#380](https://github.com/node-formidable/node-formidable/pull/380), [#340](https://github.com/node-formidable/node-formidable/pull/340), [#367](https://github.com/node-formidable/node-formidable/pull/367), [#33](https://github.com/node-formidable/node-formidable/issues/33), [#498](https://github.com/node-formidable/node-formidable/issues/498), [#280](https://github.com/node-formidable/node-formidable/issues/280), [#483](https://github.com/node-formidable/node-formidable/issues/483))
  * possible partial fix of [#386](https://github.com/node-formidable/node-formidable/pull/386) with #380 (need tests and better implementation)
  * use hasOwnProperty in check against files/fields ([#522](https://github.com/node-formidable/node-formidable/pull/522))
+ * do not promote `IncomingForm` and add `exports.default` ([#529](https://github.com/node-formidable/node-formidable/pull/529))
+ * Improve examples and tests ([#523](https://github.com/node-formidable/node-formidable/pull/523))
+ * First step of Code quality improvements ([#525](https://github.com/node-formidable/node-formidable/pull/525))
 
 ### v1.2.1 (2018-03-20)
 

--- a/README.md
+++ b/README.md
@@ -34,40 +34,41 @@ This is a low-level package, and if you're using a high-level framework it may a
 Parse an incoming file upload.
 
 ```js
-var formidable = require('formidable'),
-    http = require('http'),
-    util = require('util');
+const http = require('http');
+const util = require('util');
+const Formidable = require('formidable');
 
-http.createServer(function(req, res) {
-  if (req.url == '/upload' && req.method.toLowerCase() == 'post') {
+http.createServer((req, res) => {
+  if (req.url === '/upload' && req.method.toLowerCase() === 'post') {
     // parse a file upload
-    var form = new formidable.IncomingForm();
+    const form = new Formidable();
 
-    form.parse(req, function(err, fields, files) {
-      res.writeHead(200, {'content-type': 'text/plain'});
+    form.parse(req, (err, fields, files) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
       res.write('received upload:\n\n');
-      res.end(util.inspect({fields: fields, files: files}));
+      res.end(util.inspect({ fields: fields, files: files }));
     });
 
     return;
   }
 
   // show a file upload form
-  res.writeHead(200, {'content-type': 'text/html'});
-  res.end(
-    '<form action="/upload" enctype="multipart/form-data" method="post">'+
-    '<input type="text" name="title"><br>'+
-    '<input type="file" name="upload" multiple="multiple"><br>'+
-    '<input type="submit" value="Upload">'+
-    '</form>'
-  );
+  res.writeHead(200, { 'content-type': 'text/html' });
+  res.end(`
+    <form action="/upload" enctype="multipart/form-data" method="post">
+      <input type="text" name="title" /><br/>
+      <input type="file" name="upload" multiple="multiple" /><br/>
+      <input type="submit" value="Upload" />
+    </form>
+  `);
 }).listen(8080);
 ```
+
 ## API
 
-### Formidable.IncomingForm
+### Formidable
 ```javascript
-var form = new formidable.IncomingForm()
+const form = new Formidable()
 ```
 Creates a new incoming form.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,6 @@
-var IncomingForm = require('./incoming_form').IncomingForm;
+const { IncomingForm } = require('./incoming_form');
+
 IncomingForm.IncomingForm = IncomingForm;
-module.exports = IncomingForm;
+
+exports.default = IncomingForm;
+module.exports = exports.default;


### PR DESCRIPTION
- add `exports.default`
- update readme examples to **NOT** include `.IncomingForm` - it's unnecessary.

I don't want to promote using IncomingForm. It's still there for backward compat, but... never use it more.